### PR TITLE
Slabs or blocks config + Bug fixes

### DIFF
--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_12.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_12.java
@@ -178,24 +178,61 @@ public class VehicleMovement1_12 {
         Location loc = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset, zvp, fbvp.getYaw(), fbvp.getPitch());
         int data = loc.getBlock().getData();
         String locY = String.valueOf(mainStand.getLocation().getY());
-        if (locY.substring(locY.length() - 2).contains(".5")) {
-            if (loc.getBlock().getType().toString().contains("AIR")) {
+        Location locBlockAbove = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset + 1, zvp, fbvp.getYaw(), fbvp.getPitch());;
+
+        if (driveUpSlabs()){
+            if (!locY.substring(locY.length() - 2).contains(".5")) {
+                if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
+                    VehicleData.speed.put(license, 0.0);
+                }
+            }
+            if (locY.substring(locY.length() - 2).contains(".5")) {
+                if (loc.getBlock().getType().toString().contains("AIR")) {
+                    return;
+                }
+                if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
+                    if (loc.getBlock().getType().toString().contains("DOUBLE")) {
+                        return;
+                    }
+                }
+                ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
                 return;
             }
             if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
                 if (loc.getBlock().getType().toString().contains("DOUBLE")) {
                     return;
                 }
+                if (data < 9) {
+                    ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                }
             }
-            ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
-            return;
-        }
-        if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-            if (loc.getBlock().getType().toString().contains("DOUBLE")) {
-                return;
+        } else {
+            if (!locY.substring(locY.length() - 2).contains(".5")) {
+                if (!loc.getBlock().isPassable()) {
+                    if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
+                        if (!loc.getBlock().getType().toString().contains("DOUBLE")) {
+                            return;
+                        }
+                    }
+
+                    if (!locBlockAbove.getBlock().getType().toString().contains("AIR")) { //if more than 1 block high
+                        return;
+                    }
+
+                    ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                }
             }
-            if (data < 9) {
+            if (locY.substring(locY.length() - 2).contains(".5")) { //Only if a vehicle is placed on a slab
+                if (loc.getBlock().getType().toString().contains("AIR")) {
+                    return;
+                }
+                if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
+                    if (loc.getBlock().getType().toString().contains("DOUBLE")) {
+                        return;
+                    }
+                }
                 ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                return;
             }
         }
     }
@@ -274,5 +311,12 @@ public class VehicleMovement1_12 {
         final Location loc = new Location(main.getWorld(), xvp, main.getLocation().getY() + yOffset, zvp, seatas.getLocation().getYaw(), fbvp.getPitch());
         EntityArmorStand stand = ((CraftArmorStand) seatas).getHandle();
         stand.setLocation(loc.getX(), loc.getY(), loc.getZ(), seatas.getLocation().getYaw() + 15, seatas.getLocation().getPitch());
+    }
+
+    private static boolean driveUpSlabs(){
+        if (Main.defaultConfig.getConfig().getString("driveUp").equals("blocks")){
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_12.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_12.java
@@ -214,7 +214,7 @@ public class VehicleMovement1_12 {
                         return;
                     }
 
-                    ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                    ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 1, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
                 }
             }
             if (locY.substring(locY.length() - 2).contains(".5")) { //Only if a vehicle is placed on a slab
@@ -222,7 +222,7 @@ public class VehicleMovement1_12 {
                     return;
                 }
                 if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-                    if (loc.getBlock().getType().toString().contains("DOUBLE")) {
+                    if (!loc.getBlock().getType().toString().contains("DOUBLE")) {
                         return;
                     }
                 }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_12.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_12.java
@@ -203,7 +203,7 @@ public class VehicleMovement1_12 {
             }
         } else {
             if (!locY.substring(locY.length() - 2).contains(".5")) {
-                if (!loc.getBlock().isPassable()) {
+                if (!loc.getBlock().getType().toString().contains("AIR")) {
                     if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
                         if (!loc.getBlock().getType().toString().contains("DOUBLE")) {
                             return;

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_12.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_12.java
@@ -181,11 +181,6 @@ public class VehicleMovement1_12 {
         Location locBlockAbove = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset + 1, zvp, fbvp.getYaw(), fbvp.getPitch());;
 
         if (driveUpSlabs()){
-            if (!locY.substring(locY.length() - 2).contains(".5")) {
-                if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-                    VehicleData.speed.put(license, 0.0);
-                }
-            }
             if (locY.substring(locY.length() - 2).contains(".5")) {
                 if (loc.getBlock().getType().toString().contains("AIR")) {
                     return;

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_13.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_13.java
@@ -6,6 +6,7 @@ import nl.mtvehicles.core.Main;
 import nl.mtvehicles.core.infrastructure.helpers.BossBarUtils;
 import nl.mtvehicles.core.infrastructure.helpers.VehicleData;
 import org.bukkit.*;
+import org.bukkit.block.data.type.Slab;
 import org.bukkit.craftbukkit.v1_13_R2.entity.CraftArmorStand;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
@@ -165,30 +166,64 @@ public class VehicleMovement1_13 {
             int data = loc.getBlock().getData();
             System.out.println(loc.getBlock().getType().toString() + " " + data);
             String locY = String.valueOf(mainStand.getLocation().getY());
-            if (!locY.substring(locY.length() - 2).contains(".5")) {
-                if (!loc.getBlock().isPassable() && !loc.getBlock().getType().toString().contains("STEP") && !loc.getBlock().getType().toString().contains("SLAB")) {
-                    VehicleData.speed.put(license, 0.0);
-                }
-            }
-            if (locY.substring(locY.length() - 2).contains(".5")) {
+            Location locBlockAbove = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset + 1, zvp, fbvp.getYaw(), fbvp.getPitch());;
 
-                if (loc.getBlock().getType().toString().contains("AIR")) {
+            if (driveUpSlabs()){
+                if (!locY.substring(locY.length() - 2).contains(".5")) {
+                    if (loc.getBlock().getBlockData() instanceof Slab) {
+                        VehicleData.speed.put(license, 0.0);
+                    }
+                }
+                if (locY.substring(locY.length() - 2).contains(".5")) {
+                    if (loc.getBlock().getType().toString().contains("AIR")) {
+                        return;
+                    }
+                    if (loc.getBlock().getBlockData() instanceof Slab) {
+                        Slab slab = (Slab) loc.getBlock().getBlockData();
+                        if (slab.getType().toString().equals("BOTTOM")) {
+                            return;
+                        }
+                    }
+                    ((org.bukkit.craftbukkit.v1_13_R2.entity.CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
                     return;
                 }
-                if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-                    if (loc.getBlock().getType().toString().contains("DOUBLE")) {
+                if (loc.getBlock().getBlockData() instanceof Slab){
+                    Slab slab = (Slab) loc.getBlock().getBlockData();
+                    if (slab.getType().toString().equals("BOTTOM")){
+                        ((org.bukkit.craftbukkit.v1_13_R2.entity.CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                    } else {
                         return;
                     }
                 }
-                ((org.bukkit.craftbukkit.v1_13_R2.entity.CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
-                return;
-            }
-            if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-                if (loc.getBlock().getType().toString().contains("DOUBLE")) {
-                    return;
+            } else {
+                if (!locY.substring(locY.length() - 2).contains(".5")) {
+                    if (!loc.getBlock().isPassable()) {
+                        if (loc.getBlock().getBlockData() instanceof Slab){
+                            Slab slab = (Slab) loc.getBlock().getBlockData();
+                            if (slab.getType().toString().equals("BOTTOM")){
+                                return;
+                            }
+                        }
+
+                        if (!locBlockAbove.getBlock().getType().toString().contains("AIR")) { //if more than 1 block high
+                            return;
+                        }
+
+                        ((org.bukkit.craftbukkit.v1_13_R2.entity.CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 1, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                    }
                 }
-                if (data < 9) {
+                if (locY.substring(locY.length() - 2).contains(".5")) { //Only if a vehicle is placed on a slab
+                    if (loc.getBlock().getType().toString().contains("AIR")) {
+                        return;
+                    }
+                    if (loc.getBlock().getBlockData() instanceof Slab){
+                        Slab slab = (Slab) loc.getBlock().getBlockData();
+                        if (slab.getType().toString().equals("DOUBLE")){
+                            return;
+                        }
+                    }
                     ((org.bukkit.craftbukkit.v1_13_R2.entity.CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                    return;
                 }
             }
         });
@@ -271,6 +306,13 @@ public class VehicleMovement1_13 {
             net.minecraft.server.v1_13_R2.EntityArmorStand stand = ((org.bukkit.craftbukkit.v1_13_R2.entity.CraftArmorStand) seatas).getHandle();
             stand.setLocation(loc.getX(), loc.getY(), loc.getZ(), seatas.getLocation().getYaw() + 15, seatas.getLocation().getPitch());
         });
+    }
+
+    private static boolean driveUpSlabs(){
+        if (Main.defaultConfig.getConfig().getString("driveUp").equals("blocks")){
+            return false;
+        }
+        return true;
     }
 
 }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_13.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_13.java
@@ -213,7 +213,7 @@ public class VehicleMovement1_13 {
                     }
                     if (loc.getBlock().getBlockData() instanceof Slab){
                         Slab slab = (Slab) loc.getBlock().getBlockData();
-                        if (slab.getType().toString().equals("DOUBLE")){
+                        if (!slab.getType().toString().equals("DOUBLE")){
                             return;
                         }
                     }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_13.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_13.java
@@ -169,11 +169,6 @@ public class VehicleMovement1_13 {
             Location locBlockAbove = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset + 1, zvp, fbvp.getYaw(), fbvp.getPitch());;
 
             if (driveUpSlabs()){
-                if (!locY.substring(locY.length() - 2).contains(".5")) {
-                    if (loc.getBlock().getBlockData() instanceof Slab) {
-                        VehicleData.speed.put(license, 0.0);
-                    }
-                }
                 if (locY.substring(locY.length() - 2).contains(".5")) {
                     if (loc.getBlock().getType().toString().contains("AIR")) {
                         return;

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_13.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_13.java
@@ -164,7 +164,6 @@ public class VehicleMovement1_13 {
             float xvp = (float) (fbvp.getX() + zOffset * Math.cos(Math.toRadians(fbvp.getYaw())));
             Location loc = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset, zvp, fbvp.getYaw(), fbvp.getPitch());
             int data = loc.getBlock().getData();
-            System.out.println(loc.getBlock().getType().toString() + " " + data);
             String locY = String.valueOf(mainStand.getLocation().getY());
             Location locBlockAbove = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset + 1, zvp, fbvp.getYaw(), fbvp.getPitch());;
 

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_14.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_14.java
@@ -164,7 +164,6 @@ public class VehicleMovement1_14 {
             float xvp = (float) (fbvp.getX() + zOffset * Math.cos(Math.toRadians(fbvp.getYaw())));
             Location loc = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset, zvp, fbvp.getYaw(), fbvp.getPitch());
             int data = loc.getBlock().getData();
-            System.out.println(loc.getBlock().getType().toString() + " " + data);
             String locY = String.valueOf(mainStand.getLocation().getY());
             Location locBlockAbove = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset + 1, zvp, fbvp.getYaw(), fbvp.getPitch());;
 

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_14.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_14.java
@@ -213,7 +213,7 @@ public class VehicleMovement1_14 {
                     }
                     if (loc.getBlock().getBlockData() instanceof Slab){
                         Slab slab = (Slab) loc.getBlock().getBlockData();
-                        if (slab.getType().toString().equals("DOUBLE")){
+                        if (!slab.getType().toString().equals("DOUBLE")){
                             return;
                         }
                     }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_14.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_14.java
@@ -6,6 +6,7 @@ import nl.mtvehicles.core.Main;
 import nl.mtvehicles.core.infrastructure.helpers.BossBarUtils;
 import nl.mtvehicles.core.infrastructure.helpers.VehicleData;
 import org.bukkit.*;
+import org.bukkit.block.data.type.Slab;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftArmorStand;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
@@ -165,30 +166,64 @@ public class VehicleMovement1_14 {
             int data = loc.getBlock().getData();
             System.out.println(loc.getBlock().getType().toString() + " " + data);
             String locY = String.valueOf(mainStand.getLocation().getY());
-            if (!locY.substring(locY.length() - 2).contains(".5")) {
-                if (!loc.getBlock().isPassable() && !loc.getBlock().getType().toString().contains("STEP") && !loc.getBlock().getType().toString().contains("SLAB")) {
-                    VehicleData.speed.put(license, 0.0);
-                }
-            }
-            if (locY.substring(locY.length() - 2).contains(".5")) {
+            Location locBlockAbove = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset + 1, zvp, fbvp.getYaw(), fbvp.getPitch());;
 
-                if (loc.getBlock().getType().toString().contains("AIR")) {
+            if (driveUpSlabs()){
+                if (!locY.substring(locY.length() - 2).contains(".5")) {
+                    if (loc.getBlock().getBlockData() instanceof Slab) {
+                        VehicleData.speed.put(license, 0.0);
+                    }
+                }
+                if (locY.substring(locY.length() - 2).contains(".5")) {
+                    if (loc.getBlock().getType().toString().contains("AIR")) {
+                        return;
+                    }
+                    if (loc.getBlock().getBlockData() instanceof Slab) {
+                        Slab slab = (Slab) loc.getBlock().getBlockData();
+                        if (slab.getType().toString().equals("BOTTOM")) {
+                            return;
+                        }
+                    }
+                    ((org.bukkit.craftbukkit.v1_14_R1.entity.CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
                     return;
                 }
-                if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-                    if (loc.getBlock().getType().toString().contains("DOUBLE")) {
+                if (loc.getBlock().getBlockData() instanceof Slab){
+                    Slab slab = (Slab) loc.getBlock().getBlockData();
+                    if (slab.getType().toString().equals("BOTTOM")){
+                        ((org.bukkit.craftbukkit.v1_14_R1.entity.CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                    } else {
                         return;
                     }
                 }
-                ((org.bukkit.craftbukkit.v1_14_R1.entity.CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
-                return;
-            }
-            if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-                if (loc.getBlock().getType().toString().contains("DOUBLE")) {
-                    return;
+            } else {
+                if (!locY.substring(locY.length() - 2).contains(".5")) {
+                    if (!loc.getBlock().isPassable()) {
+                        if (loc.getBlock().getBlockData() instanceof Slab){
+                            Slab slab = (Slab) loc.getBlock().getBlockData();
+                            if (slab.getType().toString().equals("BOTTOM")){
+                                return;
+                            }
+                        }
+
+                        if (!locBlockAbove.getBlock().getType().toString().contains("AIR")) { //if more than 1 block high
+                            return;
+                        }
+
+                        ((org.bukkit.craftbukkit.v1_14_R1.entity.CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 1, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                    }
                 }
-                if (data < 9) {
+                if (locY.substring(locY.length() - 2).contains(".5")) { //Only if a vehicle is placed on a slab
+                    if (loc.getBlock().getType().toString().contains("AIR")) {
+                        return;
+                    }
+                    if (loc.getBlock().getBlockData() instanceof Slab){
+                        Slab slab = (Slab) loc.getBlock().getBlockData();
+                        if (slab.getType().toString().equals("DOUBLE")){
+                            return;
+                        }
+                    }
                     ((org.bukkit.craftbukkit.v1_14_R1.entity.CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                    return;
                 }
             }
         });
@@ -271,6 +306,13 @@ public class VehicleMovement1_14 {
             net.minecraft.server.v1_14_R1.EntityArmorStand stand = ((org.bukkit.craftbukkit.v1_14_R1.entity.CraftArmorStand) seatas).getHandle();
             stand.setLocation(loc.getX(), loc.getY(), loc.getZ(), seatas.getLocation().getYaw() + 15, seatas.getLocation().getPitch());
         });
+    }
+
+    private static boolean driveUpSlabs(){
+        if (Main.defaultConfig.getConfig().getString("driveUp").equals("blocks")){
+            return false;
+        }
+        return true;
     }
 
 }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_14.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_14.java
@@ -169,11 +169,6 @@ public class VehicleMovement1_14 {
             Location locBlockAbove = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset + 1, zvp, fbvp.getYaw(), fbvp.getPitch());;
 
             if (driveUpSlabs()){
-                if (!locY.substring(locY.length() - 2).contains(".5")) {
-                    if (loc.getBlock().getBlockData() instanceof Slab) {
-                        VehicleData.speed.put(license, 0.0);
-                    }
-                }
                 if (locY.substring(locY.length() - 2).contains(".5")) {
                     if (loc.getBlock().getType().toString().contains("AIR")) {
                         return;

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_15.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_15.java
@@ -5,10 +5,8 @@ import net.minecraft.server.v1_15_R1.PacketPlayInSteerVehicle;
 import nl.mtvehicles.core.Main;
 import nl.mtvehicles.core.infrastructure.helpers.BossBarUtils;
 import nl.mtvehicles.core.infrastructure.helpers.VehicleData;
-import org.bukkit.Effect;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.Particle;
+import org.bukkit.*;
+import org.bukkit.block.data.type.Slab;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftArmorStand;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
@@ -169,29 +167,61 @@ public class VehicleMovement1_15 {
         Location loc = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset, zvp, fbvp.getYaw(), fbvp.getPitch());
         int data = loc.getBlock().getData();
         String locY = String.valueOf(mainStand.getLocation().getY());
-        if (!locY.substring(locY.length() - 2).contains(".5")) {
-            if (!loc.getBlock().isPassable() && !loc.getBlock().getType().toString().contains("STEP") && !loc.getBlock().getType().toString().contains("SLAB")) {
-                VehicleData.speed.put(license, 0.0);
+
+        if (driveUpSlabs()){
+            if (!locY.substring(locY.length() - 2).contains(".5")) {
+                if (loc.getBlock().getBlockData() instanceof Slab) {
+                    VehicleData.speed.put(license, 0.0);
+                }
             }
-        }
-        if (locY.substring(locY.length() - 2).contains(".5")) {
-            if (loc.getBlock().getType().toString().contains("AIR")) {
+            if (locY.substring(locY.length() - 2).contains(".5")) {
+                if (loc.getBlock().getType().toString().contains("AIR")) {
+                    return;
+                }
+                if (loc.getBlock().getBlockData() instanceof Slab) {
+                    Slab slab = (Slab) loc.getBlock().getBlockData();
+                    if (slab.getType().toString().equals("BOTTOM")) {
+                        return;
+                    }
+                }
+                ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
                 return;
             }
-            if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-                if (loc.getBlock().getType().toString().contains("DOUBLE")) {
+            if (loc.getBlock().getBlockData() instanceof Slab){
+                Slab slab = (Slab) loc.getBlock().getBlockData();
+                if (slab.getType().toString().equals("BOTTOM")){
+                    ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                } else {
                     return;
                 }
             }
-            ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
-            return;
-        }
-        if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-            if (loc.getBlock().getType().toString().contains("DOUBLE")) {
-                return;
+        } else {
+            if (!locY.substring(locY.length() - 2).contains(".5")) {
+                if (!loc.getBlock().isPassable()) {
+                    if (loc.getBlock().getBlockData() instanceof Slab){
+                        Slab slab = (Slab) loc.getBlock().getBlockData();
+                        if (slab.getType().toString().equals("BOTTOM")){
+                            return;
+                        }
+                    }
+
+                    //TODO: IF IT'S MORE THAN 1 BLOCK HIGH
+
+                    ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 1, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                }
             }
-            if (data < 9) {
+            if (locY.substring(locY.length() - 2).contains(".5")) { //Only if a vehicle is placed on a slab
+                if (loc.getBlock().getType().toString().contains("AIR")) {
+                    return;
+                }
+                if (loc.getBlock().getBlockData() instanceof Slab){
+                    Slab slab = (Slab) loc.getBlock().getBlockData();
+                    if (slab.getType().toString().equals("DOUBLE")){
+                        return;
+                    }
+                }
                 ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                return;
             }
         }
     }
@@ -270,5 +300,16 @@ public class VehicleMovement1_15 {
         final Location loc = new Location(main.getWorld(), xvp, main.getLocation().getY() + yOffset, zvp, seatas.getLocation().getYaw(), fbvp.getPitch());
         EntityArmorStand stand = ((CraftArmorStand) seatas).getHandle();
         stand.setLocation(loc.getX(), loc.getY(), loc.getZ(), seatas.getLocation().getYaw() + 15, seatas.getLocation().getPitch());
+    }
+
+    private static boolean driveUpSlabs(){
+        if (Main.defaultConfig.getConfig().getString("driveUp").equals("blocks")){
+            return false;
+        }
+        return true;
+    }
+
+    private static void debugConsoleLog(String s){
+        Bukkit.getConsoleSender().sendMessage(s);
     }
 }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_15.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_15.java
@@ -214,7 +214,7 @@ public class VehicleMovement1_15 {
                 }
                 if (loc.getBlock().getBlockData() instanceof Slab){
                     Slab slab = (Slab) loc.getBlock().getBlockData();
-                    if (slab.getType().toString().equals("DOUBLE")){
+                    if (!slab.getType().toString().equals("DOUBLE")){
                         return;
                     }
                 }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_15.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_15.java
@@ -167,6 +167,7 @@ public class VehicleMovement1_15 {
         Location loc = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset, zvp, fbvp.getYaw(), fbvp.getPitch());
         int data = loc.getBlock().getData();
         String locY = String.valueOf(mainStand.getLocation().getY());
+        Location locBlockAbove = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset + 1, zvp, fbvp.getYaw(), fbvp.getPitch());;
 
         if (driveUpSlabs()){
             if (!locY.substring(locY.length() - 2).contains(".5")) {
@@ -205,7 +206,9 @@ public class VehicleMovement1_15 {
                         }
                     }
 
-                    //TODO: IF IT'S MORE THAN 1 BLOCK HIGH
+                    if (!locBlockAbove.getBlock().getType().toString().contains("AIR")) { //if more than 1 block high
+                        return;
+                    }
 
                     ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 1, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
                 }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_15.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_15.java
@@ -170,11 +170,6 @@ public class VehicleMovement1_15 {
         Location locBlockAbove = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset + 1, zvp, fbvp.getYaw(), fbvp.getPitch());;
 
         if (driveUpSlabs()){
-            if (!locY.substring(locY.length() - 2).contains(".5")) {
-                if (loc.getBlock().getBlockData() instanceof Slab) {
-                    VehicleData.speed.put(license, 0.0);
-                }
-            }
             if (locY.substring(locY.length() - 2).contains(".5")) {
                 if (loc.getBlock().getType().toString().contains("AIR")) {
                     return;

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_16.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_16.java
@@ -228,7 +228,7 @@ public class VehicleMovement1_16 {
 
                     Bukkit.getScheduler().runTask(Main.instance, () -> {
                         try {
-                            ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                            ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 1, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
                         } catch (Exception e) {
                             // e.printStackTrace();
                         }
@@ -241,7 +241,7 @@ public class VehicleMovement1_16 {
                 }
                 if (loc.getBlock().getBlockData() instanceof Slab){
                     Slab slab = (Slab) loc.getBlock().getBlockData();
-                    if (slab.getType().toString().equals("DOUBLE")){
+                    if (!slab.getType().toString().equals("DOUBLE")){
                         return;
                     }
                 }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_16.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_16.java
@@ -179,11 +179,6 @@ public class VehicleMovement1_16 {
         Location locBlockAbove = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset + 1, zvp, fbvp.getYaw(), fbvp.getPitch());;
 
         if (driveUpSlabs()){
-            if (!locY.substring(locY.length() - 2).contains(".5")) {
-                if (loc.getBlock().getBlockData() instanceof Slab) {
-                    VehicleData.speed.put(license, 0.0);
-                }
-            }
             if (locY.substring(locY.length() - 2).contains(".5")) {
                 if (loc.getBlock().getType().toString().contains("AIR")) {
                     return;

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_16.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_16.java
@@ -6,6 +6,7 @@ import nl.mtvehicles.core.Main;
 import nl.mtvehicles.core.infrastructure.helpers.BossBarUtils;
 import nl.mtvehicles.core.infrastructure.helpers.VehicleData;
 import org.bukkit.*;
+import org.bukkit.block.data.type.Slab;
 import org.bukkit.craftbukkit.v1_16_R3.entity.CraftArmorStand;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
@@ -175,34 +176,24 @@ public class VehicleMovement1_16 {
         Location loc = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset, zvp, fbvp.getYaw(), fbvp.getPitch());
         int data = loc.getBlock().getData();
         String locY = String.valueOf(mainStand.getLocation().getY());
-        if (!locY.substring(locY.length() - 2).contains(".5")) {
-            if (!loc.getBlock().isPassable() && !loc.getBlock().getType().toString().contains("STEP") && !loc.getBlock().getType().toString().contains("SLAB")) {
-                VehicleData.speed.put(license, 0.0);
+        Location locBlockAbove = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset + 1, zvp, fbvp.getYaw(), fbvp.getPitch());;
+
+        if (driveUpSlabs()){
+            if (!locY.substring(locY.length() - 2).contains(".5")) {
+                if (loc.getBlock().getBlockData() instanceof Slab) {
+                    VehicleData.speed.put(license, 0.0);
+                }
             }
-        }
-        if (locY.substring(locY.length() - 2).contains(".5")) {
-            if (loc.getBlock().getType().toString().contains("AIR")) {
-                return;
-            }
-            if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-                if (loc.getBlock().getType().toString().contains("DOUBLE")) {
+            if (locY.substring(locY.length() - 2).contains(".5")) {
+                if (loc.getBlock().getType().toString().contains("AIR")) {
                     return;
                 }
-            }
-            Bukkit.getScheduler().runTask(Main.instance, () -> {
-                try {
-                    ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
-                } catch (Exception e) {
-                    // e.printStackTrace();
+                if (loc.getBlock().getBlockData() instanceof Slab) {
+                    Slab slab = (Slab) loc.getBlock().getBlockData();
+                    if (slab.getType().toString().equals("BOTTOM")) {
+                        return;
+                    }
                 }
-            });
-            return;
-        }
-        if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-            if (loc.getBlock().getType().toString().contains("DOUBLE")) {
-                return;
-            }
-            if (data < 9) {
                 Bukkit.getScheduler().runTask(Main.instance, () -> {
                     try {
                         ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
@@ -210,6 +201,63 @@ public class VehicleMovement1_16 {
                         // e.printStackTrace();
                     }
                 });
+                return;
+            }
+            if (loc.getBlock().getBlockData() instanceof Slab){
+                Slab slab = (Slab) loc.getBlock().getBlockData();
+                if (slab.getType().toString().equals("BOTTOM")){
+                    Bukkit.getScheduler().runTask(Main.instance, () -> {
+                        try {
+                            ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                        } catch (Exception e) {
+                            // e.printStackTrace();
+                        }
+                    });
+                } else {
+                    return;
+                }
+            }
+        } else {
+            if (!locY.substring(locY.length() - 2).contains(".5")) {
+                if (!loc.getBlock().isPassable()) {
+                    if (loc.getBlock().getBlockData() instanceof Slab){
+                        Slab slab = (Slab) loc.getBlock().getBlockData();
+                        if (slab.getType().toString().equals("BOTTOM")){
+                            return;
+                        }
+                    }
+
+                    if (!locBlockAbove.getBlock().getType().toString().contains("AIR")) { //if more than 1 block high
+                        return;
+                    }
+
+                    Bukkit.getScheduler().runTask(Main.instance, () -> {
+                        try {
+                            ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                        } catch (Exception e) {
+                            // e.printStackTrace();
+                        }
+                    });
+                }
+            }
+            if (locY.substring(locY.length() - 2).contains(".5")) { //Only if a vehicle is placed on a slab
+                if (loc.getBlock().getType().toString().contains("AIR")) {
+                    return;
+                }
+                if (loc.getBlock().getBlockData() instanceof Slab){
+                    Slab slab = (Slab) loc.getBlock().getBlockData();
+                    if (slab.getType().toString().equals("DOUBLE")){
+                        return;
+                    }
+                }
+                Bukkit.getScheduler().runTask(Main.instance, () -> {
+                    try {
+                        ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                    } catch (Exception e) {
+                        // e.printStackTrace();
+                    }
+                });
+                return;
             }
         }
     }
@@ -309,5 +357,12 @@ public class VehicleMovement1_16 {
                 // e.printStackTrace();
             }
         });
+    }
+
+    private static boolean driveUpSlabs(){
+        if (Main.defaultConfig.getConfig().getString("driveUp").equals("blocks")){
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_17.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_17.java
@@ -177,11 +177,6 @@ public class VehicleMovement1_17 {
         Location locBlockAbove = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset + 1, zvp, fbvp.getYaw(), fbvp.getPitch());;
 
         if (driveUpSlabs()){
-            if (!locY.substring(locY.length() - 2).contains(".5")) {
-                if (loc.getBlock().getBlockData() instanceof Slab) {
-                    VehicleData.speed.put(license, 0.0);
-                }
-            }
             if (locY.substring(locY.length() - 2).contains(".5")) {
                 if (loc.getBlock().getType().toString().contains("AIR")) {
                     return;

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_17.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_17.java
@@ -217,7 +217,7 @@ public class VehicleMovement1_17 {
                     }
 
                     Bukkit.getScheduler().runTask(Main.instance, () -> {
-                        ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                        ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 1, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
                     });
                 }
             }
@@ -227,7 +227,7 @@ public class VehicleMovement1_17 {
                 }
                 if (loc.getBlock().getBlockData() instanceof Slab){
                     Slab slab = (Slab) loc.getBlock().getBlockData();
-                    if (slab.getType().toString().equals("DOUBLE")){
+                    if (!slab.getType().toString().equals("DOUBLE")){
                         return;
                     }
                 }

--- a/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_17.java
+++ b/src/main/java/nl/mtvehicles/core/movement/VehicleMovement1_17.java
@@ -6,6 +6,7 @@ import nl.mtvehicles.core.Main;
 import nl.mtvehicles.core.infrastructure.helpers.BossBarUtils;
 import nl.mtvehicles.core.infrastructure.helpers.VehicleData;
 import org.bukkit.*;
+import org.bukkit.block.data.type.Slab;
 import org.bukkit.craftbukkit.v1_17_R1.entity.CraftArmorStand;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
@@ -173,33 +174,72 @@ public class VehicleMovement1_17 {
         Location loc = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset, zvp, fbvp.getYaw(), fbvp.getPitch());
         int data = loc.getBlock().getData();
         String locY = String.valueOf(mainStand.getLocation().getY());
-        if (!locY.substring(locY.length() - 2).contains(".5")) {
-            if (!loc.getBlock().isPassable() && !loc.getBlock().getType().toString().contains("STEP") && !loc.getBlock().getType().toString().contains("SLAB")) {
-                VehicleData.speed.put(license, 0.0);
-            }
-        }
-        if (locY.substring(locY.length() - 2).contains(".5")) {
-            if (loc.getBlock().getType().toString().contains("AIR")) {
-                return;
-            }
-            if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-                if (loc.getBlock().getType().toString().contains("DOUBLE")) {
-                    return;
+        Location locBlockAbove = new Location(mainStand.getWorld(), xvp, mainStand.getLocation().getY() + yOffset + 1, zvp, fbvp.getYaw(), fbvp.getPitch());;
+
+        if (driveUpSlabs()){
+            if (!locY.substring(locY.length() - 2).contains(".5")) {
+                if (loc.getBlock().getBlockData() instanceof Slab) {
+                    VehicleData.speed.put(license, 0.0);
                 }
             }
-            Bukkit.getScheduler().runTask(Main.instance, () -> {
-                ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
-            });
-            return;
-        }
-        if (loc.getBlock().getType().toString().contains("STEP") || loc.getBlock().getType().toString().contains("SLAB")) {
-            if (loc.getBlock().getType().toString().contains("DOUBLE")) {
-                return;
-            }
-            if (data < 9) {
+            if (locY.substring(locY.length() - 2).contains(".5")) {
+                if (loc.getBlock().getType().toString().contains("AIR")) {
+                    return;
+                }
+                if (loc.getBlock().getBlockData() instanceof Slab) {
+                    Slab slab = (Slab) loc.getBlock().getBlockData();
+                    if (slab.getType().toString().equals("BOTTOM")) {
+                        return;
+                    }
+                }
                 Bukkit.getScheduler().runTask(Main.instance, () -> {
                     ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
                 });
+                return;
+            }
+            if (loc.getBlock().getBlockData() instanceof Slab){
+                Slab slab = (Slab) loc.getBlock().getBlockData();
+                if (slab.getType().toString().equals("BOTTOM")){
+                    Bukkit.getScheduler().runTask(Main.instance, () -> {
+                        ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                    });
+                } else {
+                    return;
+                }
+            }
+        } else {
+            if (!locY.substring(locY.length() - 2).contains(".5")) {
+                if (!loc.getBlock().isPassable()) {
+                    if (loc.getBlock().getBlockData() instanceof Slab){
+                        Slab slab = (Slab) loc.getBlock().getBlockData();
+                        if (slab.getType().toString().equals("BOTTOM")){
+                            return;
+                        }
+                    }
+
+                    if (!locBlockAbove.getBlock().getType().toString().contains("AIR")) { //if more than 1 block high
+                        return;
+                    }
+
+                    Bukkit.getScheduler().runTask(Main.instance, () -> {
+                        ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                    });
+                }
+            }
+            if (locY.substring(locY.length() - 2).contains(".5")) { //Only if a vehicle is placed on a slab
+                if (loc.getBlock().getType().toString().contains("AIR")) {
+                    return;
+                }
+                if (loc.getBlock().getBlockData() instanceof Slab){
+                    Slab slab = (Slab) loc.getBlock().getBlockData();
+                    if (slab.getType().toString().equals("DOUBLE")){
+                        return;
+                    }
+                }
+                Bukkit.getScheduler().runTask(Main.instance, () -> {
+                    ((CraftArmorStand) mainStand).getHandle().setLocation(mainStand.getLocation().getX(), mainStand.getLocation().getY() + 0.5, mainStand.getLocation().getZ(), mainStand.getLocation().getYaw(), mainStand.getLocation().getPitch());
+                });
+                return;
             }
         }
     }
@@ -284,5 +324,12 @@ public class VehicleMovement1_17 {
         Bukkit.getScheduler().runTask(Main.instance, () -> {
             stand.setLocation(loc.getX(), loc.getY(), loc.getZ(), seatas.getLocation().getYaw() + 15, seatas.getLocation().getPitch());
         });
+    }
+
+    private static boolean driveUpSlabs(){
+        if (Main.defaultConfig.getConfig().getString("driveUp").equals("blocks")){
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -6,7 +6,7 @@
 #---------------------------------------------------------------------------
 
 # Blijf hiervan af want je plugin gaat sowieso kapot als je dit aanpast!
-Config-Versie: 2.1.1
+Config-Versie: 2.2.1
 
 # Dont change this, else your plugin can be broke.
 messagesLanguage: ns
@@ -52,6 +52,10 @@ hornCooldown: 5
 
 # Type of horn, later will be added that you can change the types for each car
 hornType: "minetopiaclassic.horn1"
+
+# Whether the vehicles should be able to drive up hills by slabs ('slabs') or full blocks ('blocks').
+# Default: 'slabs'
+driveUp: 'slabs'
 
 # Een lijst met toegestane blokken om een auto op te kunnen plaatsen
 blockWhitelist:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -54,7 +54,7 @@ hornCooldown: 5
 hornType: "minetopiaclassic.horn1"
 
 # Whether the vehicles should be able to drive up hills by slabs ('slabs') or full blocks ('blocks').
-# Default: 'slabs'
+# Default: 'slabs' (If your input is not recognized, the default shall be used.)
 driveUp: 'slabs'
 
 # Een lijst met toegestane blokken om een auto op te kunnen plaatsen

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: MTVehicles
-version: 2.1.1
+version: 2.2.1
 main: nl.mtvehicles.core.Main
 api-version: 1.13
 commands:


### PR DESCRIPTION
Improved code, added config option to choose between driving on slabs or blocks.

Sadly, 1.12 does not support detecting top slabs so it works a bit differently in comparison with other versions.